### PR TITLE
Track via capture on focus and blur

### DIFF
--- a/test.js
+++ b/test.js
@@ -27,7 +27,8 @@ if (typeof document == "undefined") {
     })
   }
 
-  // useCapture=true so that stopPropagation within has no effect
+  // https://github.com/ryanve/focux/pull/1
+  // useCapture=true to track anywhere in document
   document.addEventListener("focus", report, true)
   document.addEventListener("blur", report, true)
   report()

--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ if (typeof document == "undefined") {
   }
 
   // useCapture=true so that stopPropagation within has no effect
-  document.addEventListener("focusin", report, true)
-  document.addEventListener("focusout", report, true)
+  document.addEventListener("focus", report, true)
+  document.addEventListener("blur", report, true)
   report()
 }


### PR DESCRIPTION


> [The `focusin` and `focusout` events fire just before the element gains or loses focus, and they bubble. By contrast, the `focus` and `blur` events fire after the focus has shifted, and don't bubble.](https://caniuse.com/#feat=focusin-focusout-events)