### PR TITLE
Use sans-serif

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="https://unpkg.com/preset.css@0.2.0/preset.css">
 <style>
   [href] { color: inherit }
-  html { background: DimGray; color: WhiteSmoke; font: caption }
+  html { background: DimGray; color: WhiteSmoke; font: 1em/normal sans-serif }
   .able { background: Navy; color: WhiteSmoke; font-weight: 500 }
   * { border: .25rem dashed transparent }
   :focus-within { background: DeepPink; border-color: Pink }


### PR DESCRIPTION
`font: caption` was using a `serif` on Firefox and Safari